### PR TITLE
feat: quiz flow & party-match logic (PR #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
         "format": "prettier --write ."
     },
     "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
         "next": "14.1.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-hook-form": "^7.51.4",
+        "zod": "^3.23.8"
     },
     "devDependencies": {
         "@types/node": "^20.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.0.1
+        version: 5.0.1(react-hook-form@7.57.0(react@18.3.1))
       next:
         specifier: 14.1.0
         version: 14.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17,6 +20,12 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.51.4
+        version: 7.57.0(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.51
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
@@ -90,6 +99,11 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@hookform/resolvers@5.0.1':
+    resolution: {integrity: sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -214,6 +228,9 @@ packages:
 
   '@rushstack/eslint-patch@1.11.0':
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
@@ -1475,6 +1492,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.57.0:
+    resolution: {integrity: sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1821,6 +1844,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.51:
+    resolution: {integrity: sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -1863,6 +1889,11 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@hookform/resolvers@5.0.1(react-hook-form@7.57.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.57.0(react@18.3.1)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -1962,6 +1993,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.11.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.2':
     dependencies:
@@ -3409,6 +3442,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-hook-form@7.57.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-is@16.13.1: {}
 
   react@18.3.1:
@@ -3875,3 +3912,5 @@ snapshots:
   yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.51: {}

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,7 +1,49 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import SliderField from "@/components/SliderField";
+
+const schema = z.object({
+  security: z.number().min(0).max(100),
+  socioEconomic: z.number().min(0).max(100),
+  religious: z.number().min(0).max(100),
+});
+type FormValues = z.infer<typeof schema>;
+
 export default function QuizPage() {
+  const router = useRouter();
+  const { control, handleSubmit } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { security: 50, socioEconomic: 50, religious: 50 },
+  });
+
+  const onSubmit = (data: FormValues) => {
+    const params = new URLSearchParams({
+      s: data.security.toString(),
+      e: data.socioEconomic.toString(),
+      r: data.religious.toString(),
+    });
+    router.push(`/result?${params.toString()}`);
+  };
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p className="text-lg">🛠️ Quiz flow to be implemented in next PR.</p>
+    <div className="mx-auto max-w-md space-y-6 p-4">
+      <h2 className="text-2xl font-semibold text-center">הזז/י את הסליידרים</h2>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <SliderField name="security" label="ביטחון" control={control} />
+        <SliderField name="socioEconomic" label="חברתי-כלכלי" control={control} />
+        <SliderField name="religious" label="דתי" control={control} />
+
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-brand-600 py-3 text-white hover:opacity-90 transition"
+        >
+          המשך
+        </button>
+      </form>
     </div>
   );
-} 
+}

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,7 +1,55 @@
-export default function ResultPage() {
+import { matchParty } from "@/lib/matchParty";
+import { parties } from "@/data/parties";
+import { notFound } from "next/navigation";
+
+function parseParam(p?: string): number | null {
+  const n = Number(p);
+  return Number.isFinite(n) ? Math.min(Math.max(n, 0), 100) : null;
+}
+
+export default function ResultPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const security = parseParam(searchParams.s as string);
+  const socioEconomic = parseParam(searchParams.e as string);
+  const religious = parseParam(searchParams.r as string);
+
+  if (security === null || socioEconomic === null || religious === null) return notFound();
+
+  const party = matchParty({ security, socioEconomic, religious });
+
+  const others = parties
+    .filter((p) => p.id !== party.id)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p className="text-lg">🛠️ Result screen coming soon.</p>
+    <div className="mx-auto max-w-md space-y-6 p-4">
+      <h2 className="text-2xl font-semibold text-center">התוצאה שלך</h2>
+
+      <div className="rounded-2xl bg-neutral-100 p-4 shadow">
+        <p className="text-center text-xl font-bold text-brand-600">{party.name}</p>
+      </div>
+
+      <details className="rounded bg-neutral-100 p-4">
+        <summary className="cursor-pointer select-none">פירוט מלא של הדירוג</summary>
+        <ul className="mt-2 list-disc px-4 space-y-1">
+          {others.map((p) => (
+            <li key={p.id}>{p.name}</li>
+          ))}
+        </ul>
+      </details>
+
+      <button
+        onClick={() =>
+          navigator.share?.({ url: window.location.href }) ??
+          navigator.clipboard.writeText(window.location.href)
+        }
+        className="w-full rounded-lg bg-brand-600 py-3 text-white hover:opacity-90 transition"
+      >
+        שתף/י את התוצאה
+      </button>
     </div>
   );
-} 
+}

--- a/src/components/SliderField.tsx
+++ b/src/components/SliderField.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Controller, Control } from "react-hook-form";
+
+interface Props {
+  name: "security" | "socioEconomic" | "religious";
+  label: string;
+  control: Control<{
+    security: number;
+    socioEconomic: number;
+    religious: number;
+  }>;
+}
+
+export default function SliderField({ name, label, control }: Props) {
+  return (
+    <div className="space-y-2">
+      <label className="block font-medium">{label}</label>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            {...field}
+            className="w-full accent-brand-600"
+          />
+        )}
+      />
+      <div className="flex justify-between text-xs text-neutral-500">
+        <span>0</span>
+        <span>25</span>
+        <span>50</span>
+        <span>75</span>
+        <span>100</span>
+      </div>
+    </div>
+  );
+}

--- a/src/data/parties.ts
+++ b/src/data/parties.ts
@@ -1,0 +1,30 @@
+export interface Party {
+  id: string;
+  name: string;
+  security: number;
+  socioEconomic: number;
+  religious: number;
+}
+
+export const parties: Party[] = [
+  { id: "likud", name: "הליכוד", security: 80, socioEconomic: 65, religious: 70 },
+  { id: "yesh_atid", name: "יש עתיד", security: 60, socioEconomic: 40, religious: 30 },
+  {
+    id: "machane_mamlachti",
+    name: "המחנה הממלכתי",
+    security: 75,
+    socioEconomic: 45,
+    religious: 35,
+  },
+  { id: "shas", name: "ש״ס", security: 60, socioEconomic: 35, religious: 90 },
+  { id: "yahadut_hatora", name: "יהדות התורה", security: 40, socioEconomic: 30, religious: 95 },
+  { id: "tzionut_datit", name: "הציונות הדתית", security: 90, socioEconomic: 60, religious: 85 },
+  { id: "otzma_yehudit", name: "עוצמה יהודית", security: 95, socioEconomic: 55, religious: 80 },
+  { id: "yisrael_beitenu", name: "ישראל ביתנו", security: 85, socioEconomic: 70, religious: 15 },
+  { id: "avoda", name: "העבודה", security: 40, socioEconomic: 25, religious: 20 },
+  { id: "meretz", name: "מרצ", security: 25, socioEconomic: 20, religious: 10 },
+  { id: "hadash_taal", name: "חד״ש-תע״ל", security: 20, socioEconomic: 30, religious: 10 },
+  { id: "raam", name: "רע״ם", security: 30, socioEconomic: 35, religious: 60 },
+  { id: "balad", name: "בל״ד", security: 15, socioEconomic: 25, religious: 30 },
+  { id: "bennett2026", name: "בנט 2026", security: 90, socioEconomic: 65, religious: 80 },
+];

--- a/src/lib/matchParty.ts
+++ b/src/lib/matchParty.ts
@@ -1,0 +1,25 @@
+import { parties, Party } from "@/data/parties";
+
+export interface Answers {
+  security: number;
+  socioEconomic: number;
+  religious: number;
+}
+
+export function matchParty(answers: Answers): Party {
+  let best: Party = parties[0];
+  let bestDistance = Infinity;
+
+  for (const p of parties) {
+    const d =
+      (answers.security - p.security) ** 2 +
+      (answers.socioEconomic - p.socioEconomic) ** 2 +
+      (answers.religious - p.religious) ** 2;
+
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = p;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
### PR #3 — “feat: quiz flow & party-match logic”

#### ✨ What’s new
* **Interactive quiz (`/quiz`)**  
  * Three RTL sliders built with `react-hook-form` + `zod` validation  
  * Default values = 50/50/50
* **Party-match algorithm** (`src/lib/matchParty.ts`)  
  * Euclidean distance on the three axes  
  * Uses seed data in `src/data/parties.ts`
* **Result screen (`/result`)**  
  * Shows top match, accordion with all other parties, “Share” button (Web Share API or clipboard)  
  * Reads answers from query-string so the URL is shareable
* **UI components**  
  * Reusable `SliderField` with brand accent colour
* **Deps added:** `react-hook-form`, `zod`

#### 🔍 How to test
```bash
pnpm dev
# Navigate to /quiz, move sliders, click Continue
# Verify result page shows expected party, copy/share URL, reload → same result
npm run lint           # should pass
