### PR TITLE
feat: intended-vote question + bar chart (PR #7)

### DIFF
--- a/src/components/PartySelect.tsx
+++ b/src/components/PartySelect.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { parties } from "../data/parties";
+
+interface Props {
+  value: string | "";
+  onChange: (v: string) => void;
+}
+
+export default function PartySelect({ value, onChange }: Props) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded-lg border p-2"
+    >
+      <option value="">בחר/י מפלגה</option>
+      {parties.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.name}
+        </option>
+      ))}
+      <option value="undecided">לא החלטתי</option>
+    </select>
+  );
+}

--- a/src/components/StatsCharts.tsx
+++ b/src/components/StatsCharts.tsx
@@ -9,6 +9,9 @@ import {
   Tooltip,
   Scatter,
   ResponsiveContainer,
+  BarChart,
+  Bar,
+  Tooltip as BarTooltip,
 } from "recharts";
 import { supabase } from "../lib/supabaseClient";
 
@@ -16,6 +19,7 @@ interface Point {
   x: number;
   y: number;
   z: number; // religious score for future heat-map
+  intended?: string | null;
 }
 
 export default function StatsCharts() {
@@ -25,13 +29,14 @@ export default function StatsCharts() {
     async function fetch() {
       const { data, error } = await supabase
         .from("responses")
-        .select("security, socio_economic, religious");
+        .select("security, socio_economic, religious, intended_vote");
       if (!error && data) {
         setPoints(
           data.map((r) => ({
             x: r.security,
             y: r.socio_economic,
             z: r.religious,
+            intended: r.intended_vote,
           })),
         );
       }
@@ -43,15 +48,42 @@ export default function StatsCharts() {
     return <p className="mt-12 text-center">אין עדיין נתונים להצגה.</p>;
   }
 
+  const voteCounts = points
+    .filter((p) => p.intended)
+    .reduce<Record<string, number>>((acc, p) => {
+      const key = p.intended as string;
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+
+  const barData = Object.entries(voteCounts).map(([name, count]) => ({
+    name,
+    count,
+  }));
+
   return (
-    <ResponsiveContainer width="100%" height={400}>
-      <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-        <CartesianGrid />
-        <XAxis type="number" dataKey="x" name="ביטחון" domain={[0, 100]} tickCount={5} />
-        <YAxis type="number" dataKey="y" name="חברתי-כלכלי" domain={[0, 100]} tickCount={5} />
-        <Tooltip cursor={{ strokeDasharray: "3 3" }} />
-        <Scatter data={points} fill="#0A66C2" shape="circle" opacity={0.75} />
-      </ScatterChart>
-    </ResponsiveContainer>
+    <>
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+          <CartesianGrid />
+          <XAxis type="number" dataKey="x" name="ביטחון" domain={[0, 100]} tickCount={5} />
+          <YAxis type="number" dataKey="y" name="חברתי-כלכלי" domain={[0, 100]} tickCount={5} />
+          <Tooltip cursor={{ strokeDasharray: "3 3" }} />
+          <Scatter data={points} fill="#0A66C2" shape="circle" opacity={0.75} />
+        </ScatterChart>
+      </ResponsiveContainer>
+
+      {barData.length > 0 && (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={barData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Bar dataKey="count" fill="#0A66C2" />
+            <BarTooltip />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </>
   );
 }

--- a/src/lib/saveResponse.ts
+++ b/src/lib/saveResponse.ts
@@ -4,18 +4,9 @@ interface Payload {
   security: number;
   socio_economic: number;
   religious: number;
+  intended_vote?: string | null;
 }
 
 export async function saveResponse(payload: Payload) {
-  try {
-    const { error } = await supabase.from("responses").insert(payload);
-
-    if (error) {
-      console.error("Failed to save response:", error);
-      // Don't throw - we don't want to break the UI
-    }
-  } catch (e) {
-    console.error("Unexpected error saving response:", e);
-    // Don't throw - we don't want to break the UI
-  }
+  await supabase.from("responses").insert(payload).throwOnError();
 }


### PR DESCRIPTION
### PR #7 — “feat: intended-vote question + bar chart”

#### ✨ What’s new
* **Result page**
  * Adds optional drop-down “Which party are you planning to vote for?”  
  * Two buttons: **Submit** (enabled when a party is chosen) & **Skip**  
  * On click → saves sliders + `intended_vote` (or NULL) and redirects to `/stats`
* **DB**
  * `alter table responses add column intended_vote text`
* **Stats page**
  * Existing scatter plot unchanged  
  * NEW bar chart counts non-null `intended_vote` values
* **Components**
  * `PartySelect` reusable select populated from `src/data/parties`
* **Policies**
  * Select policy already allows reading the new column; no change needed.

#### 🔍 How to test
1. Run the SQL migration in Supabase.
2. `pnpm dev` → complete a quiz → choose a party, hit **Submit**.  
   * Row appears with `intended_vote` populated.
   * `/stats` shows both scatter and a bar for that party.  
3. Try **Skip** – row saved with `intended_vote` = NULL, bar chart unaffected.

#### ✅ Reviewer checklist
- [x] “Submit” enabled only after selection; “Skip” always enabled  
- [x] Redirect lands on `/stats` and charts update  
- [x] Column exists; NULL allowed  
- [ ] No duplicate rows written (answers saved once per completion)  
- [ ] No new lint / TS errors

> Next (small) PR will add an edge-function rate-limit and the “delete my data” link.
